### PR TITLE
versioning infos conforming to mix and elixir 0.10.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,12 +2,13 @@ defmodule Properex.MixFile do
   use Mix.Project
 
   def project do
-    [app: :properex, version: "0.1", deps: deps]
+    [app: :properex, version: "0.1", deps: deps, elixir: ">= 0.10.0"]
   end
 
   def application, do: []
 
   defp deps do
-    [{:proper, %r(.*), git: "https://github.com/manopapad/proper"}]
+    [ # proper has no explicit version config but tags in github
+    {:proper, ">= 1.1", git: "https://github.com/manopapad/proper"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,1 @@
-[ "proper": {:git,"https://github.com/manopapad/proper","80c2c73b1d416fce9704ec850e1b770488603257",[]} ]
+[ "proper": {:git, "https://github.com/manopapad/proper", "aa6b088607a08b82ef765dfdfcb6f20f0735915f", []} ]


### PR DESCRIPTION
Hi Yurii, 

the dependenciy of proper uses the nowadays outdated regex versioniong. This results in warnings during every mix run with properex as a dependency. This pull request fixes this issue. 

Regards,
Klaus.
